### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: pull-request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/object88/kctx/security/code-scanning/1](https://github.com/object88/kctx/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow appears to only build and test code (no deployment, no issue or PR modification), the minimal permission of `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies to a specific job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made by adding the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
